### PR TITLE
Add monochromatic neutral color palette to the design of Cico

### DIFF
--- a/manual-tests.txt
+++ b/manual-tests.txt
@@ -59,6 +59,21 @@ Use `./build.sh` to build CiCo and `./run.sh` to run it if using the command lin
 2. Enter 00000000 into the field and click Update.
 
 ## Expected results
-* Should display "Developer" for the user name.
+* Should display "Developer" for the username.
 
 
+# Module 6:  Aesthetic and minimalist design.
+
+## Test steps
+1. Build and run CiCo.
+2. Enter 00000000 into the field and click Update.
+3. Wait for status panel to close.
+4. Enter 00000000 into the field and click Update.
+5. Enter 99999999 into the field and click Update.
+6. Wait for status panel to close.
+
+## Expected results
+* Should display a neutral monochrome color after step 1.
+* Should display a neutral monochrome color "Checked IN" after step 2.
+* Should display a neutral monochrome color "Checked OUT" after step 4.
+* The panel should display a neutral monochrome color "Please show your card to staff to validate." after step 5.

--- a/src/edu/cvtc/itsd/Main.java
+++ b/src/edu/cvtc/itsd/Main.java
@@ -241,13 +241,13 @@ public class Main {
     panelMain.setMinimumSize(new Dimension(320, 240));
     panelMain.setPreferredSize(new Dimension(640, 480));
     panelMain.setMaximumSize(new Dimension(640, 480));
-    panelMain.setBackground(Color.black);
+    panelMain.setBackground(Color.decode("#352E19"));
 
     panelMain.add(Box.createVerticalGlue());
     JLabel labelDirective = new JLabel("Scan card", JLabel.LEADING);
     labelDirective.setFont(fontMain);
     labelDirective.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelDirective.setForeground(Color.cyan);
+    labelDirective.setForeground(Color.decode("#EDE8DA"));
     panelMain.add(labelDirective);
 
     fieldNumber = new JTextField();
@@ -256,14 +256,14 @@ public class Main {
     fieldNumber.setPreferredSize(new Dimension(200, 32));
     fieldNumber.setMaximumSize(new Dimension(200, 32));
     fieldNumber.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    fieldNumber.setBackground(Color.green);
-    fieldNumber.setForeground(Color.magenta);
+    fieldNumber.setBackground(Color.decode("#cbbd93"));
+    fieldNumber.setForeground(Color.decode("#352E19"));
     panelMain.add(fieldNumber);
 
     JButton updateButton = new JButton("Update");
     updateButton.setAlignmentX(JComponent.CENTER_ALIGNMENT);
     updateButton.addActionListener(new Update());
-    updateButton.setForeground(Color.green);
+    updateButton.setForeground(Color.decode("#352E19"));
     panelMain.add(updateButton);
 
     panelMain.add(Box.createVerticalGlue());
@@ -274,19 +274,19 @@ public class Main {
     panelStatus.setMinimumSize(new Dimension(320, 240));
     panelStatus.setPreferredSize(new Dimension(640, 480));
     panelStatus.setMaximumSize(new Dimension(640, 480));
-    panelStatus.setBackground(Color.blue);
+    panelStatus.setBackground(Color.decode("#80775c"));
 
     panelStatus.add(Box.createVerticalGlue());
     labelUser = new JLabel("Registrant", JLabel.LEADING);
     labelUser.setFont(fontMain);
     labelUser.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelUser.setForeground(Color.yellow);
+    labelUser.setForeground(Color.decode("#fae8b4"));
     panelStatus.add(labelUser);
 
     labelState = new JLabel("updated", JLabel.LEADING);
     labelState.setFont(fontMain);
     labelState.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelState.setForeground(Color.magenta);
+    labelState.setForeground(Color.decode("#EDE8DA"));
     panelStatus.add(labelState);
 
     panelStatus.add(Box.createVerticalGlue());
@@ -297,19 +297,19 @@ public class Main {
     panelError.setMinimumSize(new Dimension(320, 240));
     panelError.setPreferredSize(new Dimension(640, 480));
     panelError.setMaximumSize(new Dimension(640, 480));
-    panelError.setBackground(Color.red);
+    panelError.setBackground(Color.decode("#fae8b4"));
 
     panelError.add(Box.createVerticalGlue());
     labelReason = new JLabel("", JLabel.LEADING);
     labelReason.setFont(fontMain);
     labelReason.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelReason.setForeground(Color.yellow);
+    labelReason.setForeground(Color.decode("#574a24"));
     panelError.add(labelReason);
 
     buttonAcknowledge = new JButton("OK");
     buttonAcknowledge.addActionListener(handler);
     buttonAcknowledge.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    buttonAcknowledge.setForeground(Color.red);
+    buttonAcknowledge.setForeground(Color.decode("#111111"));
     panelError.add(buttonAcknowledge);
     panelError.add(Box.createVerticalGlue());
 
@@ -322,8 +322,8 @@ public class Main {
     // Module 2 ticket: Add version number.
     JLabel labelMeta = new JLabel("CiCo v" + VERSION);
     labelMeta.setOpaque(true);
-    labelMeta.setBackground(Color.darkGray);
-    labelMeta.setForeground(Color.white);
+    labelMeta.setBackground(Color.decode("#574a24"));
+    labelMeta.setForeground(Color.decode("#EDE8DA"));
     labelMeta.setBorder(new EmptyBorder(10, 10, 10, 10));
     labelMeta.setMinimumSize(new Dimension(320, 32));
     labelMeta.setPreferredSize(new Dimension(640, 32));


### PR DESCRIPTION
Add monochromatic neutral color palette to the design of Cico and add tests to see the color palette on all screens.